### PR TITLE
Added lang=None to get_tts for compatibility

### DIFF
--- a/ovos_tts_plugin_mimic/__init__.py
+++ b/ovos_tts_plugin_mimic/__init__.py
@@ -92,7 +92,7 @@ class MimicTTSPlugin(TTS):
             [expanduser(self.mimic_bin), '-lv']).\
             decode("utf-8").split(":")[-1].strip().split(" ")
 
-    def get_tts(self, sentence, wav_file):
+    def get_tts(self, sentence, wav_file, lang=None):
         """Generate WAV and phonemes.
 
         Arguments:


### PR DESCRIPTION
Done nothing, just want this TTS to be able to be called with the lang parameter for consistency with the other TTS.
To the best of my knowledge Mimic only works in English.